### PR TITLE
Input width as an Integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default Vue.directive('google-identity-login-btn', {
       size: binding.value.size || "large",
       locale: binding.value.locale || "es-419",
       logo_alignment: binding.value.logo_alignment || "center",
-      width: binding.value.width || '300'
+      width: binding.value.width || 300
     };
 
     const googleLoginButtonId = el.id;


### PR DESCRIPTION
Google changed the way they managed the optional width parameter. A string "200" etc used to work fine, but from this morning (in some EU zones) it looks like we need to use an Integer to get the button displayed.

Feel free to double check this information. I also opened a ticket with Google to check this.